### PR TITLE
Work around "'BinaryDistribution' object has no attribute 'exclude_pa…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ skbuild.setup(
     package_data={
         'memtrace': memtrace_data,
     },
+    exclude_package_data={},
     entry_points={
         'console_scripts': [
             'memtrace=memtrace.cli:main',


### PR DESCRIPTION
…ckage_data'"

Triggered by "./ci-docker --arch=s390x".