### PR TITLE
Disable valgrind automake dependency tracking in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       run: python3 setup.py sdist
 
     - name: Build
-      run: PATH=/usr/lib/ccache:$PATH ./ci --skip-repair
+      run: PATH=/usr/lib/ccache:$PATH ./ci
+               --skip-repair
+               -DVALGRIND_CONFIGURE_FLAGS=--disable-dependency-tracking
 
     - name: Smoke test
       run: python3 -m pip install --user dist/wheelhouse/*.whl &&
@@ -113,6 +115,7 @@ jobs:
       run: ./ci-docker
                --arch=${{ matrix.arch }}
                --python=${{ matrix.python }}
+               -DVALGRIND_CONFIGURE_FLAGS=--disable-dependency-tracking
 
     - name: Show ccache stats
       run: ccache --show-stats --verbose

--- a/.github/workflows/ci.yml.j2
+++ b/.github/workflows/ci.yml.j2
@@ -76,7 +76,9 @@ jobs:
       run: python3 setup.py sdist
 
     - name: Build
-      run: PATH=/usr/lib/ccache:$PATH ./ci --skip-repair
+      run: PATH=/usr/lib/ccache:$PATH ./ci
+               --skip-repair
+               -DVALGRIND_CONFIGURE_FLAGS=--disable-dependency-tracking
 
     - name: Smoke test
       run: python3 -m pip install --user dist/wheelhouse/*.whl &&
@@ -103,6 +105,7 @@ jobs:
       run: ./ci-docker
                --arch={% raw %}${{ matrix.arch }}{% endraw %}
                --python={% raw %}${{ matrix.python }}{% endraw %}
+               -DVALGRIND_CONFIGURE_FLAGS=--disable-dependency-tracking
 {{ steps_post("cross-${{ matrix.arch }}-${{ matrix.python }}") }}
 
   PyPI:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_custom_command(
                     --prefix=${valgrind_install}
                     --with-mpicc=false
                     --with-gdbscripts-dir=no
+                    ${VALGRIND_CONFIGURE_FLAGS}
     DEPENDS ${valgrind_src}/configure
     WORKING_DIRECTORY ${valgrind_build}
 )


### PR DESCRIPTION
Locally this saves 15 seconds.

https://www.gnu.org/software/automake/manual/automake.html#Dependencies