### PR TITLE
Allow interrupting `memtrace report` with Ctrl+C

### DIFF
--- a/memtrace_ext/memtrace_ext.cc
+++ b/memtrace_ext/memtrace_ext.cc
@@ -757,6 +757,9 @@ class Trace : public TraceBase {
 
   template <typename V, typename F>
   int VisitOne(V* visitor, const F& filter) {
+    if (PyErr_CheckSignals()) {
+      boost::python::throw_error_already_set();
+    }
     if (!Have(Tlv<E, W>::kFixedLength)) return -EINVAL;
     Tlv<E, W> tlv(cur_);
     if (!Have(tlv.GetAlignedLength())) return -EINVAL;


### PR DESCRIPTION
Performance impact:
Before: 948.1 ms ±   9.8 ms
After:  960.0 ms ±  41.7 ms

Closes #103